### PR TITLE
Fix `string.Split()` usage on multi-character strings

### DIFF
--- a/GenXdev.FileSystem.psm1
+++ b/GenXdev.FileSystem.psm1
@@ -914,7 +914,7 @@ Multiple overrides:
                 }
                 else {
 
-                    throw "Could not parse parameter -$CommandName $AttributeSet - '$PSIem' is not valid
+                    throw "Could not parse parameter -$CommandName $AttributeSet - '$PSItem' is not valid
     possible attributes to combine: [RASHCNETO]
 
     R - Read only
@@ -968,13 +968,13 @@ Multiple overrides:
             }
 
             # split up
-            $allSwitches = $switchesCleaned.Replace(" -/", " /-").Split(" /", [System.StringSplitOptions]::RemoveEmptyEntries);
+            $allSwitches = $switchesCleaned.Replace(" -/", " /-").Split([string[]]@(" /"), [System.StringSplitOptions]::RemoveEmptyEntries);
 
             # enumerate switches
             $allSwitches | ForEach-Object -ErrorAction SilentlyContinue {
 
                 # add to Dictionary
-                $switchesDictionary["$($PSItem.Trim().Split(" ")[0].Split(":" )[0].Trim().ToUpperInvariant())"] = $PSItem.Trim()
+                $switchesDictionary["$($PSItem.Trim().Split(" ")[0].Split(":")[0].Trim().ToUpperInvariant())"] = $PSItem.Trim()
             }
 
             return $switchesDictionary;
@@ -1513,7 +1513,7 @@ Multiple overrides:
             $paramList = @{};
             (& $RobocopyPath -?) | ForEach-Object {
                 if ($PSItem.Contains(" :: ")) {
-                    $s = $PSItem.Split(" :: ", [StringSplitOptions]::RemoveEmptyEntries);
+                    $s = $PSItem.Split([string[]]@(" :: "), [StringSplitOptions]::RemoveEmptyEntries);
                     $paramList."$($s[0].ToLowerInvariant().split(":")[0].Split("[")[0].Trim().split(" ")[0])" = $s[1];
                 }
             };
@@ -1521,7 +1521,7 @@ Multiple overrides:
             $first = $true;
             $paramsExplained = @(
 
-                " $switchesCleaned ".Split(" /", [System.StringSplitOptions]::RemoveEmptyEntries) |
+                " $switchesCleaned ".Split([string[]]@(" /"), [System.StringSplitOptions]::RemoveEmptyEntries) |
                 ForEach-Object {
 
                     $description = $paramList."/$($PSItem.ToLowerInvariant().split(":")[0].Split("[")[0].Trim().split(" ")[0])"


### PR DESCRIPTION
Changes:

- Explicitly cast the multi-char arguments into type `string[]` to force the correct `Split()` overload to be selected

- Bonus Fix: Fixes typo in throw statement `$PSIem` --> `$PSItem`

Notes:

- Fixes Issues: #1 (broken `-FileExcludeFilter`) and #3 (broken `-WhatIf`)

- This is required because the default overload of `string.Split()` treats the first argument as a **character** set, not as a literal string.

    ```ps1
    > "".Split

    OverloadDefinitions
    -------------------
    string[] Split(Params char[] separator)
    string[] Split(char[] separator, int count)
    string[] Split(char[] separator, System.StringSplitOptions options)
    string[] Split(char[] separator, int count, System.StringSplitOptions options)
    string[] Split(string[] separator, System.StringSplitOptions options)
    string[] Split(string[] separator, int count, System.StringSplitOptions options)
    ```

- example

  ```ps1
  $teststr = "one, two three"
  $str_a = $teststr.Split(            ", ",  [StringSplitOptions]::RemoveEmptyEntries)
  $str_b = $teststr.Split([string[]]@(", "), [StringSplitOptions]::RemoveEmptyEntries)

  $str_a 
  #  one 
  #  two 
  #  three

  $str_b 
  #  one 
  #  two three
  ```

Refs:
- Issue 1: <https://github.com/renevaessen/GenXdev.FileSystem/issues/1>
- Issue 3: <https://github.com/renevaessen/GenXdev.FileSystem/issues/3>